### PR TITLE
Fix benchmark timing bug

### DIFF
--- a/recblock-sptrsv/recblocking_calculate.h
+++ b/recblock-sptrsv/recblocking_calculate.h
@@ -95,10 +95,25 @@ void L_calculate(SpMV_block *mv_blk,
                 }
                 else if (trsv_blk[tri_index].method == 3)
                 {
+                    cudaMemcpy(trsv_blk[tri_index].d_graphInDegreeShadow, trsv_blk[tri_index].d_graphInDegree, sizeof(int) * trsv_blk[tri_index].m, cudaMemcpyDeviceToDevice);
+                    cudaMemset(trsv_blk[tri_index].d_id_extractor, 0, sizeof(int));
+                    cudaMemset(trsv_blk[tri_index].d_left_sum, 0, sizeof(VALUE_TYPE) * trsv_blk[tri_index].m);
+
+                    cudaError_t err = cudaGetLastError();
+                    if (err != cudaSuccess)
+                    {
+                        printf("FAIL: cudaError memcpy: %s\n", cudaGetErrorString(err));
+                    }
+
                     sptrsv_syncfree_warpvec_csc_cuda_executor<<<trsv_blk[tri_index].num_blocks, trsv_blk[tri_index].num_threads>>>(&d_recblock_Ptr[ptr_offset[i] - 1], &d_recblock_Index[index_offset[i]], &d_recblock_Val[index_offset[i]],
-                                                                                                                                   trsv_blk[tri_index].d_graphInDegree, trsv_blk[tri_index].d_left_sum,
+                                                                                                                                   trsv_blk[tri_index].d_graphInDegreeShadow, trsv_blk[tri_index].d_left_sum,
                                                                                                                                    trsv_blk[tri_index].m, trsv_blk[tri_index].substitution, &b_t[b_offset], &x_t[x_offset], trsv_blk[tri_index].d_while_profiler,
                                                                                                                                    trsv_blk[tri_index].d_id_extractor, trsv_blk[tri_index].d_levelItem);
+
+                    if (cudaGetLastError() != cudaSuccess)
+                    {
+                        printf("FAIL: cudaError\n");
+                    }
                 }
                 tri_index++;
                 b_offset += blk_m[i];
@@ -347,6 +362,7 @@ void device_memfree(SpMV_block *mv_blk,
         else if (trsv_blk[i].method == 3)
         {
             cudaFree(trsv_blk[i].d_graphInDegree);
+            cudaFree(trsv_blk[i].d_graphInDegreeShadow);
             cudaFree(trsv_blk[i].d_left_sum);
             cudaFree(trsv_blk[i].d_id_extractor);
             cudaFree(trsv_blk[i].d_levelItem);

--- a/recblock-sptrsv/recblocking_preprocess.h
+++ b/recblock-sptrsv/recblocking_preprocess.h
@@ -672,6 +672,7 @@ void L_preprocessing(int *cscRowIdxTR_new,
                     cudaMemcpy((trsv_blk[trsv_count]).d_levelItem, levelItem_local, blk_m[blk_count] * sizeof(int), cudaMemcpyHostToDevice);
 
                     cudaMalloc((void **)&(trsv_blk[trsv_count]).d_graphInDegree, blk_m[blk_count] * sizeof(int));
+                    cudaMalloc((void **)&(trsv_blk[trsv_count]).d_graphInDegreeShadow, blk_m[blk_count] * sizeof(int));
                     cudaMemset((trsv_blk[trsv_count]).d_graphInDegree, 0, blk_m[blk_count] * sizeof(int));
 
                     cudaMalloc((void **)&(trsv_blk[trsv_count]).d_id_extractor, sizeof(int));
@@ -1226,6 +1227,7 @@ void U_preprocessing(int *cscRowIdxTR_new,
                     cudaMemcpy((trsv_blk[trsv_count]).d_levelItem, levelItem_local, blk_m[blk_count] * sizeof(int), cudaMemcpyHostToDevice);
 
                     cudaMalloc((void **)&(trsv_blk[trsv_count]).d_graphInDegree, blk_m[blk_count] * sizeof(int));
+                    cudaMalloc((void **)&(trsv_blk[trsv_count]).d_graphInDegreeShadow, blk_m[blk_count] * sizeof(int));
                     cudaMemset((trsv_blk[trsv_count]).d_graphInDegree, 0, blk_m[blk_count] * sizeof(int));
 
                     cudaMalloc((void **)&(trsv_blk[trsv_count]).d_id_extractor, sizeof(int));

--- a/recblock-sptrsv/recblocking_solver_cuda.h
+++ b/recblock-sptrsv/recblocking_solver_cuda.h
@@ -337,6 +337,7 @@ void recblocking_solver_cuda(int *d_cscColPtrTR,
                         cudaMemcpy((trsv_blk[trsv_count]).d_levelItem, d_levelItem_local, blk_m[blk_count] * sizeof(int), cudaMemcpyDeviceToDevice);
 
                         cudaMalloc((void **)&(trsv_blk[trsv_count]).d_graphInDegree, blk_m[blk_count] * sizeof(int));
+                        cudaMalloc((void **)&(trsv_blk[trsv_count]).d_graphInDegreeShadow, blk_m[blk_count] * sizeof(int));
                         cudaMemset((trsv_blk[trsv_count]).d_graphInDegree, 0, blk_m[blk_count] * sizeof(int));
 
                         cudaMalloc((void **)&(trsv_blk[trsv_count]).d_id_extractor, sizeof(int));
@@ -877,6 +878,7 @@ void recblocking_solver_cuda(int *d_cscColPtrTR,
                         cudaMemcpy((trsv_blk[trsv_count]).d_levelItem, d_levelItem_local, blk_m[blk_count] * sizeof(int), cudaMemcpyDeviceToDevice);
 
                         cudaMalloc((void **)&(trsv_blk[trsv_count]).d_graphInDegree, blk_m[blk_count] * sizeof(int));
+                        cudaMalloc((void **)&(trsv_blk[trsv_count]).d_graphInDegreeShadow, blk_m[blk_count] * sizeof(int));
                         cudaMemset((trsv_blk[trsv_count]).d_graphInDegree, 0, blk_m[blk_count] * sizeof(int));
 
                         cudaMalloc((void **)&(trsv_blk[trsv_count]).d_id_extractor, sizeof(int));

--- a/recblock-sptrsv/utils_sptrsv_cuda.h
+++ b/recblock-sptrsv/utils_sptrsv_cuda.h
@@ -27,6 +27,7 @@ typedef struct SpTRSV_block
     int m_lv;
     int offset;
     int *d_graphInDegree;
+    int *d_graphInDegreeShadow;
     VALUE_TYPE *d_left_sum;
     int *d_while_profiler;
     int *d_id_extractor;


### PR DESCRIPTION
When the benchmark code runs the SpTRSV algorithm in a loop, it seems that some of the intermediate buffers get modified by the CUDA kernels such that subsequent runs after the first one may not be performing all the work again, but exiting early as these intermediate data structures indicate to the kernel that the algorithm is finished. The validation code passes because the correct result is left untouched from the first iteration, so this is not a correctness issue, simply a benchmark bug.

We identified 3 such arrays - d_id_extractor, d_left_sum, and d_graphInDegree. For the first two, they are meant to be 0 upon entry to the algorithm, so we simply reset them back to zero with cudaMemset. d_graphInDegree also gets overwritten, and since we need to preserve the original, we keep a copy (d_graphInDegreeShadow) and reset it each time with cudaMemcpy.

This appears to be limited to method == 3, and recblock still performs quite well with this fix, outperforming the significantly improved (over cuSPARSE 11) cuSPARSE 13 SpTRSV by a decent margin, as well as several other methods (YYSpTRSV, CapelliniSpTRSV).